### PR TITLE
Don't require_all my bundle

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -27,7 +27,7 @@ end
 [GAMEBOX_PATH, APP_ROOT, File.join(APP_ROOT,'src')].each{|path| $: << path }
 require "gamebox_application"
 
-require_all Dir.glob("**/*.rb").reject{ |f| f.match("spec/") || f.match("src/app.rb")}
+require_all Dir.glob("src/**/*.rb").reject{ |f| f.match("src/app.rb")}
 Gosu::enable_undocumented_retrofication
 
 


### PR DESCRIPTION
`environment.rb` was overzealously requiring `*.rb` files, including from `vendor/bundle` (where I keep my bundle). 
It really only needs `src/`.
